### PR TITLE
Add deletion of analysis file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,5 +36,10 @@ subprojects {
         "-XX:MaxMetaspaceSize=512m"
       ]
     }
+    doLast {
+      if (scalaCompileOptions.force) {
+        scalaCompileOptions.incrementalOptions.analysisFile.get().asFile.delete()
+      }
+    }
   }
 }


### PR DESCRIPTION
This illustrates the workaround for the `testImplementation` issue, which is a general fix when you disable Scala incremental compilation in Gradle 6+